### PR TITLE
Fix malfunctioning change event handler

### DIFF
--- a/src/ModelList.js
+++ b/src/ModelList.js
@@ -243,7 +243,7 @@ class ModelList extends RootElem {
 		const props = this.model.props;
 
 		// for each key listed in the event, check what actually changed.
-		for (let key in Reflect.ownKeys(e)) {
+		for (let key in e) {
 			// find component that corresponds to the key, if any.
 			let cont = null;
 			for (let ct of this.components) {


### PR DESCRIPTION
A last minute "fix" effectively disabled the change event handler for
the ModelList by iterating over numeric indexes instead of the actual
keys of the event. This commit removes the "fix".